### PR TITLE
Remove Authorization header from LinkedIn API requests.

### DIFF
--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/LinkedInTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/LinkedInTemplate.java
@@ -212,6 +212,9 @@ public class LinkedInTemplate extends AbstractOAuth2ApiBinding implements Linked
 					}
 				}
 			};
+
+			// LinkedIn doesn't accept the OAuth2 Bearer token authorization header.
+			protectedResourceRequest.getHeaders().remove("Authorization"); 
 			return execution.execute(protectedResourceRequest, body);
 		}
 


### PR DESCRIPTION
LinkedIn's API doesn't accept OAuth 2 Bearer Token Authorization headers. Instead, the access token must be presented in an oauth2_access_token query parameter.
