### PR TITLE
set missing username in UserProfile

### DIFF
--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/connect/LinkedInAdapter.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/connect/LinkedInAdapter.java
@@ -50,6 +50,7 @@ public class LinkedInAdapter implements ApiAdapter<LinkedIn> {
 	public UserProfile fetchUserProfile(LinkedIn linkedin) {
 		LinkedInProfile profile = linkedin.profileOperations().getUserProfile();
 		return new UserProfileBuilder()
+				.setUsername(profile.getId())
 				.setName(profile.getFirstName() + " " + profile.getLastName())
 				.setEmail(profile.getEmailAddress())
 				.build();


### PR DESCRIPTION
Because Linkedin api does not supply an username from their api, linkedinAdoper does not set one, but leaving username as null in UserProfile makes other dependent framework like spring-social-security to break while persisting. It's good to set 'default-username' as linkedin id, as it's the only unique identity we get from linkedin.
