### PR TITLE
Add content when posting to Groups

### DIFF
--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupOperations.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupOperations.java
@@ -122,6 +122,21 @@ public interface GroupOperations {
 	 * @return the URI of the newly created Post
 	 */
 	URI createPost(Integer groupId, String title, String summary);
+
+	/**
+	 * Create a Post with Content
+	 *
+	 * @param groupId Group to Create Post on
+	 * @param postTitle Title of Post
+	 * @param postSummary Summary of Post
+	 * @param contentTitle Content title for Post
+	 * @param contentSubmittedUrl Content submitted URL for Post
+	 * @param contentSubmittedImageUrl Content submitted image URL for Post
+	 * @param contentDescription Content description
+	 * @return the URI of the newly created Post
+	 */
+	URI createPost(Integer groupId, String postTitle, String postSummary, String contentTitle,
+				   String contentSubmittedUrl, String contentSubmittedImageUrl, String contentDescription);
 	
 	/**
 	 * Like a Post

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupPost.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupPost.java
@@ -1,0 +1,72 @@
+package org.springframework.social.linkedin.api;
+
+import java.io.Serializable;
+
+import org.springframework.util.Assert;
+
+public class GroupPost implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String title; //cannot be null or empty
+    private String summary;//cannot be null but can be empty
+    private Content content;
+
+    public GroupPost(String title, String summary) {
+        Assert.notNull(title, "GroupPost's title cannot be null");
+        if(title.isEmpty()){
+            throw new IllegalArgumentException("GroupPost's title cannot be empty");
+        }
+        if(summary == null) {
+            summary = ""; // must be specified, but can be empty
+        }
+        this.title = title;
+        this.summary = summary;
+    }
+
+    public GroupPost(String title, String summary, Content content) {
+        this(title, summary);
+        this.content = content;
+    }
+
+    public String getTitle() { return title; }
+    public String getSummary() { return summary; }
+    public Content getContent() { return content; }
+
+    public static final class Content implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private String title; //cannot be null but can be empty
+        private String submittedUrl; //cannot be null, nor empty
+        private String submittedImageUrl; //can be null or empty
+        private String description; //can be null or empty
+
+        public Content(String title, String submittedUrl) {
+            Assert.notNull(submittedUrl, "GroupPost.Content's submittedUrl cannot be null");
+            if(submittedUrl.isEmpty()) {
+                throw new IllegalArgumentException("GroupPost.Content's submittedUrl cannot be empty");
+            }
+            if(title == null) {
+                title = ""; //must be specified but can be empty
+            }
+            this.title = title;
+            this.submittedUrl = submittedUrl;
+        }
+
+        public Content(String title, String submittedUrl, String submittedImageUrl) {
+            this(title, submittedUrl);
+            this.submittedImageUrl = submittedImageUrl;
+        }
+
+        public Content(String title, String submittedUrl, String submittedImageUrl, String description) {
+            this(title, submittedUrl, submittedImageUrl);
+            this.description = description;
+        }
+
+        public String getSubmittedUrl() { return submittedUrl; }
+        public String getSubmittedImageUrl() { return submittedImageUrl; }
+        public String getTitle() { return title; }
+        public String getDescription() { return description; }
+    }
+}

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/GroupTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/GroupTemplate.java
@@ -17,13 +17,12 @@ package org.springframework.social.linkedin.api.impl;
 
 import java.net.URI;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.social.linkedin.api.Group;
 import org.springframework.social.linkedin.api.Group.GroupPosts;
 import org.springframework.social.linkedin.api.GroupMemberships;
 import org.springframework.social.linkedin.api.GroupOperations;
+import org.springframework.social.linkedin.api.GroupPost;
 import org.springframework.social.linkedin.api.GroupSuggestions;
 import org.springframework.social.linkedin.api.PostComments;
 import org.springframework.web.client.RestOperations;
@@ -87,11 +86,19 @@ class GroupTemplate extends AbstractTemplate implements GroupOperations {
 		restOperations.delete(GROUP_JOIN_LEAVE_URL, groupId);
 	}
 	
-	public URI createPost(Integer groupId, String title, String summary) {
-		Map<String, String> post = new HashMap<String,String>();
-		post.put("title", title);
-		post.put("summary", summary);
-		return restOperations.postForLocation(GROUP_CREATE_POST_URL, post, groupId);
+	public URI createPost(Integer groupId, String postTitle, String postSummary) {
+		GroupPost groupPost = new GroupPost(postTitle, postSummary);
+		return restOperations.postForLocation(GROUP_CREATE_POST_URL,groupPost,
+						groupId);
+	}
+
+	public URI createPost(Integer groupId, String postTitle, String postSummary, String contentTitle,
+						  String contentSubmittedUrl, String contentSubmittedImageUrl, String contentDescription) {
+		GroupPost.Content content =
+				new GroupPost.Content(contentTitle, contentSubmittedUrl, contentSubmittedImageUrl, contentDescription);
+		GroupPost groupPost = new GroupPost(postTitle, postSummary, content);
+		return restOperations.postForLocation(GROUP_CREATE_POST_URL, groupPost,
+						groupId);
 	}
 	
 	public void likePost(String postId) {

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/GroupTemplateTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/GroupTemplateTest.java
@@ -216,13 +216,64 @@ public class GroupTemplateTest extends AbstractLinkedInApiTest {
 	public void createPost() {
 		mockServer.expect(requestTo((GroupTemplate.GROUP_CREATE_POST_URL + "?oauth2_access_token=ACCESS_TOKEN").replaceFirst("\\{group-id\\}", "4253322")))
 			.andExpect(method(POST))
-			.andExpect(content().string("{\"summary\":\"This is a test\",\"title\":\"Test Post\"}"))
+			.andExpect(content().string("{\"title\":\"Test Post\",\"summary\":\"This is a test\"}"))
 			.andRespond(withSuccess("", MediaType.APPLICATION_JSON));
 		
 		linkedIn.groupOperations().createPost(4253322, "Test Post", "This is a test");
-		
 	}
-	
+
+	@Test(expected = IllegalArgumentException.class)
+	public void createPostWithNullTitle() {
+		linkedIn.groupOperations().createPost(4253322, null, "This is a test");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void createPostWithEmptyTitle() {
+		linkedIn.groupOperations().createPost(4253322, "", "This is a test");
+	}
+
+	@Test
+	public void createPostWithNullSummary() {
+		mockServer.expect(requestTo((GroupTemplate.GROUP_CREATE_POST_URL + "?oauth2_access_token=ACCESS_TOKEN").replaceFirst("\\{group-id\\}", "4253322")))
+				.andExpect(method(POST))
+				.andExpect(content().string("{\"title\":\"Test Post\",\"summary\":\"\"}"))
+				.andRespond(withSuccess("", MediaType.APPLICATION_JSON));
+
+		linkedIn.groupOperations().createPost(4253322, "Test Post", null);
+	}
+
+	@Test
+	public void createPostWithContent() {
+		String jsonPayload = "{\"title\":\"Test Post\",\"summary\":\"This is a test\",\"content\":{\"title\":\"Content title\"," +
+				"\"submittedUrl\":\"Submitted URL\",\"submittedImageUrl\":\"SubmittedImageUrl\",\"description\":\"Description\"}}";
+		mockServer.expect(requestTo((GroupTemplate.GROUP_CREATE_POST_URL + "?oauth2_access_token=ACCESS_TOKEN").replaceFirst("\\{group-id\\}", "4253322")))
+				.andExpect(method(POST))
+				.andExpect(content().string(jsonPayload))
+				.andRespond(withSuccess("", MediaType.APPLICATION_JSON));
+		linkedIn.groupOperations().createPost(4253322, "Test Post", "This is a test", "Content title", "Submitted URL", "SubmittedImageUrl", "Description");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void createPostWithContentAndNullSubmittedUrl() {
+		linkedIn.groupOperations().createPost(4253322, "Test Post", "This is a test", "Content title", null, "SubmittedImageUrl", "Description");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void createPostWithContentAndEmptySubmittedUrl() {
+		linkedIn.groupOperations().createPost(4253322, "Test Post", "This is a test", "Content title", "", "SubmittedImageUrl", "Description");
+	}
+
+	@Test
+	public void createPostWithContentAndNullTitle() {
+		String jsonPayload = "{\"title\":\"Test Post\",\"summary\":\"This is a test\",\"content\":{\"title\":\"\"," +
+				"\"submittedUrl\":\"Submitted URL\",\"submittedImageUrl\":\"SubmittedImageUrl\",\"description\":\"Description\"}}";
+		mockServer.expect(requestTo((GroupTemplate.GROUP_CREATE_POST_URL + "?oauth2_access_token=ACCESS_TOKEN").replaceFirst("\\{group-id\\}", "4253322")))
+				.andExpect(method(POST))
+				.andExpect(content().string(jsonPayload))
+				.andRespond(withSuccess("", MediaType.APPLICATION_JSON));
+		linkedIn.groupOperations().createPost(4253322, "Test Post", "This is a test", null, "Submitted URL", "SubmittedImageUrl", "Description");
+	}
+
 	@Test
 	public void likePost() {
 		mockServer.expect(requestTo((GroupTemplate.GROUP_POST_LIKE_URL + "?oauth2_access_token=ACCESS_TOKEN").replaceFirst("\\{post-id\\}", "g-4253322-S-89528249")))


### PR DESCRIPTION
Adds the ability, when posting to a Group, to include content.  Content can contain a title, an image preview URL (submitted-image-url), and a description (these are all optional) and must contain a link/URL (submitted-url).  

Details of the corresponding LinkedIn API can be found at https://developer.linkedin.com/documents/groups-api#create

Implementation detail: the GroupPost and GroupPost.Content classes do not extend the LinkedInObject since it automatically adds the extraData field to the JSON payload in the request and LinkedIn rejects these.
