### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CodeAndName.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CodeAndName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Comment.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Comment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Comments.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Comments.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CommunicationOperations.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CommunicationOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Companies.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Companies.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Company.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Company.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CompanyJobUpdate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CompanyJobUpdate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CompanyOperations.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CompanyOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ConnectionAuthorization.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ConnectionAuthorization.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ConnectionOperations.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ConnectionOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CurrentShare.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/CurrentShare.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Education.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Education.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Group.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Group.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupMemberships.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupMemberships.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupOperations.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupSettings.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupSettings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupSuggestions.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/GroupSuggestions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ImAccount.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ImAccount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Job.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Job.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobBookmark.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobBookmark.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobBookmarks.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobBookmarks.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobOperations.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobPosition.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobPosition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobSearchParameters.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/JobSearchParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Jobs.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Jobs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Likes.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Likes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedIn.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInConnections.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInConnections.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInDate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInDate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInNetworkUpdate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInNetworkUpdate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInNetworkUpdates.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInNetworkUpdates.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInObject.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInObject.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInProfile.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInProfile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInProfileFull.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInProfileFull.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInProfiles.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/LinkedInProfiles.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Location.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Location.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/MemberGroup.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/MemberGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/NetworkStatistics.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/NetworkStatistics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/NetworkUpdateOperations.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/NetworkUpdateOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/NetworkUpdateParameters.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/NetworkUpdateParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/NewShare.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/NewShare.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/PersonActivity.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/PersonActivity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/PhoneNumber.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/PhoneNumber.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Position.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Position.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Post.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Post.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/PostComment.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/PostComment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/PostComments.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/PostComments.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Product.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Product.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Products.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Products.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ProfileField.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ProfileField.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ProfileOperations.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/ProfileOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Recommendation.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Recommendation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Relation.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Relation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/SearchParameters.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/SearchParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/SearchResult.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/SearchResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Share.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/Share.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/TwitterAccount.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/TwitterAccount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateAction.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContent.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentCompany.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentCompany.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentConnection.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentConnection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentFollow.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentFollow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentGroup.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentPersonActivity.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentPersonActivity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentRecommendation.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentRecommendation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentShare.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentShare.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentStatus.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentViral.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateContentViral.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateType.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateTypeInput.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UpdateTypeInput.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UrlResource.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/UrlResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/AbstractTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/AbstractTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/CommunicationTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/CommunicationTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/CompanyTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/CompanyTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/ConnectionTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/ConnectionTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/GroupTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/GroupTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/JobTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/JobTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/JsonFormatHeaderRequestFactory.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/JsonFormatHeaderRequestFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/LinkedInErrorHandler.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/LinkedInErrorHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/LinkedInTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/LinkedInTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/NetworkUpdateTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/NetworkUpdateTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/ProfileTemplate.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/ProfileTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/AttachmentMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/AttachmentMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CodeAndNameMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CodeAndNameMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CodeDeserializer.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CodeDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CommentMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CommentMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CommentsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CommentsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompaniesMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompaniesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyAddressMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyAddressMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyContactInfoMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyContactInfoMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyJobUpdateMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyJobUpdateMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyLocationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyLocationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CompanyMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ConnectionAuthorizationDeserializer.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ConnectionAuthorizationDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ConnectionAuthorizationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ConnectionAuthorizationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CurrentShareMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/CurrentShareMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/DeserializationUtils.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/DeserializationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/EducationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/EducationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupCountMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupCountMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupMembershipsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupMembershipsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupPostsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupPostsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupRelationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupRelationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupSettingsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupSettingsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupSuggestionsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/GroupSuggestionsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ImAccountMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ImAccountMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobBookmarkMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobBookmarkMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobBookmarksMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobBookmarksMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobPositionMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobPositionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/JobsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LikesListDeserializer.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LikesListDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LikesMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LikesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInConnectionsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInConnectionsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInDateMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInDateMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInModule.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInNetworkUpdateListDeserializer.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInNetworkUpdateListDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInNetworkUpdateMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInNetworkUpdateMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInNetworkUpdatesMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInNetworkUpdatesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInObjectMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInObjectMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInProfileFullMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInProfileFullMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInProfileMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInProfileMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInProfilesMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LinkedInProfilesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LocationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/LocationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/MemberGroupMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/MemberGroupMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/NetworkStatisticsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/NetworkStatisticsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PersonActivityMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PersonActivityMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PhoneNumberMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PhoneNumberMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PositionMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PositionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PostCommentMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PostCommentMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PostCommentsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PostCommentsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PostMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PostMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PostRelationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/PostRelationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ProductMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ProductMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ProductRecommendationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ProductRecommendationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ProductsMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ProductsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/RecommendationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/RecommendationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/RecommendationsListDeserializer.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/RecommendationsListDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/RelationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/RelationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ShareContentMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ShareContentMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ShareMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ShareMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ShareSourceMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/ShareSourceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/StringListDeserializer.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/StringListDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/TwitterAccountMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/TwitterAccountMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateActionMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateActionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentCompanyMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentCompanyMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentConnectionMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentConnectionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentFollowMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentFollowMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentGroupMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentGroupMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentPersonActivityMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentPersonActivityMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentRecommendationMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentRecommendationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentShareMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentShareMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentStatusMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentStatusMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentViralMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateContentViralMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateTypeDeserializer.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UpdateTypeDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UrlResourceMixin.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/api/impl/json/UrlResourceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/config/support/LinkedInApiHelper.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/config/support/LinkedInApiHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/config/xml/LinkedInConfigBeanDefinitionParser.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/config/xml/LinkedInConfigBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/config/xml/LinkedInNamespaceHandler.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/config/xml/LinkedInNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/connect/LinkedInAdapter.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/connect/LinkedInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/connect/LinkedInConnectionFactory.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/connect/LinkedInConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/connect/LinkedInServiceProvider.java
+++ b/spring-social-linkedin/src/main/java/org/springframework/social/linkedin/connect/LinkedInServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/AbstractLinkedInApiTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/AbstractLinkedInApiTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/CommunicationTemplateTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/CommunicationTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/CompanyTemplateTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/CompanyTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/ConnectionTemplateTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/ConnectionTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/ErrorHandlerTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/ErrorHandlerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/GroupTemplateTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/GroupTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/JobTemplateTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/JobTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/NetworkUpdateTemplateTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/NetworkUpdateTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/ProfileTemplateTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/api/impl/ProfileTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/connect/LinkedInAdapterTest.java
+++ b/spring-social-linkedin/src/test/java/org/springframework/social/linkedin/connect/LinkedInAdapterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/dist/license.txt
+++ b/src/dist/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/reference/resources/xsl/html-custom.xsl
+++ b/src/reference/resources/xsl/html-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/src/reference/resources/xsl/html-single-custom.xsl
+++ b/src/reference/resources/xsl/html-single-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/src/reference/resources/xsl/pdf-custom.xsl
+++ b/src/reference/resources/xsl/pdf-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 178 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).